### PR TITLE
Changed the callsign bytes from 32:37 to 32:38 to support valid 7 dig…

### DIFF
--- a/rs109m.py
+++ b/rs109m.py
@@ -183,12 +183,16 @@ class RS109_config:
 
     def get_callsign(self):
         # TODO: check if it is 32:37 or 32:38
-        s = fromxbit(self._config[32:37], 6, True).decode('ascii')[::-1]
+ 	# derek@conniffe.com - changed to 32:38 to
+	# support valid 7 digit callsigns
+        s = fromxbit(self._config[32:38], 6, True).decode('ascii')[::-1]
         return ''.join(c if c.isalnum() else '' for c in s)
 
     def set_callsign(self, cs):
         safe_cs = ''.join(c if c.isalnum() else '' for c in cs)
-        self._config[32:37] = toxbit(safe_cs[::-1])
+ 	# derek@conniffe.com - changed to 32:38 to
+	# support valid 7 digit callsigns
+        self._config[32:38] = toxbit(safe_cs[::-1])
 
     callsign = property(get_callsign, set_callsign)
 


### PR DESCRIPTION
Changed the callsign bytes from 32:37 to 32:38 to support valid 7 digit call signs (I found the error where it was chopping off the first character of my valid 7 digit call-sign).  I noticed there was a comment on line 185 questioning whether or not it should be 32:37 or 32:38 so perhaps this answers it.  Affects both the set_callsign and set_callsign class methods